### PR TITLE
Now displays elapsed time in nearest units

### DIFF
--- a/ltest/src/ltest/reporter.clj
+++ b/ltest/src/ltest/reporter.clj
@@ -10,7 +10,8 @@
 (defn show-summary
   [results]
   (let [total-failures (reduce + 0 (map :fail results))
-        total-errors (reduce + 0 (map :error results))]
+        total-errors (reduce + 0 (map :error results))
+        time-taken (util/nano->human-readable (reduce + 0 (mapcat :times results)))]
     (if (pos? total-failures)
       (reset! *status* :fail)
       (when (pos? total-errors)
@@ -21,7 +22,7 @@
     (println util/divider)
     (println)
     (println "Total tests:" (reduce + 0 (map :test results)))
-    (println "Time taken:" (util/nano->millis (reduce + 0 (mapcat :times results))) "ms")
+    (println "Time taken:" time-taken)
     (println "Assertion passes:" (reduce + 0 (map :pass results)))
     (println "Assertion failures:" total-failures)
     (println "Assertion errors:" total-errors)

--- a/ltest/src/ltest/util.clj
+++ b/ltest/src/ltest/util.clj
@@ -206,3 +206,12 @@
 (defn nano->micros
   [nano]
   (.toMicros TimeUnit/NANOSECONDS nano))
+
+(defn nano->human-readable
+  [nano]
+  (let [len (count (str nano))]
+    (cond
+          (< len 4) (str nano "ns")
+          (< len 7) (str (nano->micros nano) "μs")
+          (< len 10) (str (nano->millis nano) "ms")
+          :else (str (nano->seconds nano) "s"))))


### PR DESCRIPTION
Resolves issue #38 

Prints it to the nearest available unit from nano seconds up to milliseconds. If time elapsed is 1000ms then it will be printed as 1s etc.